### PR TITLE
Use CRLF for spec compliant http headers

### DIFF
--- a/src/wifi.c
+++ b/src/wifi.c
@@ -277,12 +277,12 @@ uint16_t wifi_HttpGet(char *url) {
   }
 }
 
-const char httpHeaderTpl[] = "HTTP/1.0 %d %s\n"
-                             "Server: OpenBttn\n"
-                             "Access-Control-Allow-Origin: *\n"
-                             "Content-Type: %s\n"
-                             "%s" // "Content-Encoding: %s\n"
-                             "Content-Length: %d\n\n";
+const char httpHeaderTpl[] = "HTTP/1.0 %d %s\r\n"
+                             "Server: OpenBttn\r\n"
+                             "Access-Control-Allow-Origin: *\r\n"
+                             "Content-Type: %s\r\n"
+                             "%s" // "Content-Encoding: %s\r\n"
+                             "Content-Length: %d\r\n\r\n";
 
 int wifi_CreateHttpHeader(char *dest, int len, int status,
                           const char *statusText, const char *contentType,
@@ -290,7 +290,7 @@ int wifi_CreateHttpHeader(char *dest, int len, int status,
   char contentEncoding[HTTP_HEADER_ENCODING_LENGTH + 1] = {0};
   if (contentEnc) {
     int s = snprintf(contentEncoding, HTTP_HEADER_ENCODING_LENGTH,
-                     "Content-Encoding: %s\n", contentEnc);
+                     "Content-Encoding: %s\r\n", contentEnc);
     if (s < 0) {
       return s;
     }

--- a/src/wifi.h
+++ b/src/wifi.h
@@ -64,7 +64,7 @@
 
 #define HTTP_HEADER_LENGTH 180
 #define HTTP_HEADER_ENCODING_LENGTH                                            \
-  (18 + 8) // Longest encodings are "compress" and "identity" (8 chars).
+  (18 + 8 + 2) // Longest encodings are "compress" and "identity" (8 chars).
 
 typedef uint16_t WifiState;
 


### PR DESCRIPTION
According to the [HTTP/1.0 spec](https://www.w3.org/Protocols/HTTP/1.0/spec.html) headers should be followed by CRLF (`\r\n`), and the body should be separated by a CRLF as well. Previously we only used LF which caused some clients to timeout waiting for the correct body separator.

> This was observed with Erlang's built-in `httpc` as well as `ibrowse` and `hackney`, where all connections timed out.

This issue was reported in #3.